### PR TITLE
Replace our own Icon component in Notifications with a standard svg

### DIFF
--- a/components/Notification.tsx
+++ b/components/Notification.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
+import React from "react";
 import { styled, colorHelpers, CSS, VariantProps } from "../stitches.config";
-import { Icon } from "../components/Icon";
 
 const StyledNotification = styled("div", {
   // Reset
@@ -22,7 +21,7 @@ const StyledNotification = styled("div", {
     color: "inherit",
   },
 
-  "> button.delete": {
+  "> button.delete-button": {
     backgroundColor: "transparent",
     border: "none",
     cursor: "pointer",
@@ -64,7 +63,7 @@ export const Notification = (props: NotificationProps) => {
   // Peel isClosable off, as it will make Stitches complain if it gets through
   const { isClosable, ...styleProps } = props;
 
-  const [visible, setVisible] = useState(true);
+  const [visible, setVisible] = React.useState(true);
 
   function handleCloseClick(): void {
     setVisible(false);
@@ -75,11 +74,18 @@ export const Notification = (props: NotificationProps) => {
   return (
     <StyledNotification {...styleProps}>
       {isClosable && (
-        <button className="delete" onClick={handleCloseClick}>
-          <Icon isSmall>
-            <Icon.Title>Close Notification</Icon.Title>
-            <Icon.Close />
-          </Icon>
+        <button className="delete-button" onClick={handleCloseClick}>
+          <svg
+            data-testid="icon-svg"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+          >
+            <title>Close</title>
+            <path d="M289.94 256l95-95A24 24 0 00351 127l-95 95-95-95a24 24 0 00-34 34l95 95-95 95a24 24 0 1034 34l95-95 95 95a24 24 0 0034-34z" />
+          </svg>
         </button>
       )}
       {props.children}

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -6,7 +6,7 @@ export const Tag = styled("div", {
 
   // Custom
   borderRadius: "5px",
-  padding: "$1",
+  padding: "1px $1",
   marginBottom: "$2",
   marginRight: "$2",
   backgroundColor: "$lightGrey",


### PR DESCRIPTION
For some reason pulling in the `Icon` component from our own design system repo was causing the Rollup packaging build to break in the `Notification` component.  This swaps the `Icon` out with a regular close shaped SVG.