### PR TITLE
Add lowercase variant for buttons.

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -55,6 +55,11 @@ const StyledButton = styled("button", {
 
   // Variants
   variants: {
+    isLowercase: {
+      true: {
+        textTransform: "unset",
+      },
+    },
     isLight: {
       true: {
         border: "none",
@@ -76,6 +81,7 @@ const StyledButton = styled("button", {
     isText: {
       true: {
         border: "none",
+        backgroundColor: "transparent",
         "&:hover": {
           textDecoration: "underline",
         },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -87,6 +87,7 @@ const Home: NextPage = () => {
           <Button isLight>Light Style</Button>
           <Button isDanger>Delete</Button>
           <Button isText>Plain ol text</Button>
+          <Button isLowercase>Button w/o Uppers</Button>
 
           <CodeBlock>{codeSamples.button}</CodeBlock>
 
@@ -100,6 +101,11 @@ const Home: NextPage = () => {
               {
                 name: "isLight?",
                 description: "Color style",
+                type: "boolean",
+              },
+              {
+                name: "isLowercase?",
+                description: "Text style",
                 type: "boolean",
               },
               {


### PR DESCRIPTION
This PR adds a variant for the button component allowing it to not force a text-transform of Uppercase. In some cases within meadow UI, we may want to use a <Button/> but not go with the default UPPERCASE.