### PR TITLE
Add Icon to Tag component.

### DIFF
--- a/code-samples/index.ts
+++ b/code-samples/index.ts
@@ -3,7 +3,7 @@ import { icon } from "./icon";
 import { notification } from "./notification";
 import { placeholder } from "./placeholder";
 import { popover, popoverText } from "./popover";
-import { tag } from "./tag";
+import { tag, tagIcon } from "./tag";
 
 export {
   button,
@@ -14,4 +14,5 @@ export {
   popover,
   popoverText,
   tag,
+  tagIcon,
 };

--- a/code-samples/tag.ts
+++ b/code-samples/tag.ts
@@ -3,3 +3,14 @@ import { Tag } from '@nulib/design-system';
 
 <Tag isSuccess>Published</Tag>
 `;
+
+export const tagIcon = `
+import { Icon, Tag } from '@nulib/design-system';
+
+<Tag isInfo isIcon>
+  <Icon>
+    <Icon.Video />
+  </Icon>
+  Video
+</Tag>
+`;

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -1,25 +1,38 @@
 import { styled, colorHelpers } from "../stitches.config";
+import { StyledIcon } from "./Icon.styled";
 
 export const Tag = styled("div", {
   // Reset
   boxSizing: "border-box",
 
   // Custom
+  display: "inline-flex",
+  alignItems: "center",
   borderRadius: "5px",
-  padding: "1px $1",
+  padding: "$1",
   marginBottom: "$2",
   marginRight: "$2",
   backgroundColor: "$lightGrey",
   color: "$richBlack50",
-  display: "inline-block",
   textTransform: "uppercase",
   fontSize: "$2",
+  objectFit: "contain",
 
   "&:last-child": {
     marginRight: "0",
   },
 
+  [`${StyledIcon}`]: {
+    position: "absolute",
+    left: "$1",
+    height: "$3",
+    width: "$3",
+  },
+
   variants: {
+    isIcon: {
+      true: { position: "relative", paddingLeft: "$5" },
+    },
     isDanger: {
       true: { ...colorHelpers.isDanger },
     },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 8001",
     "build": "rollup -c",
     "build:static": "next build",
     "prepublishOnly": "npm run build",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -537,6 +537,35 @@ const Home: NextPage = () => {
             ]}
           />
         </Section>
+
+        <SpacerLine />
+
+        <Section size="1">
+          <h2 id="button">Tag w/ Icon</h2>
+          <p>
+            A Tag can wrap multiple Icon components. To use an icon, as the prop
+            isIcon.
+          </p>
+
+          <Tag isInfo isIcon>
+            <Icon>
+              <Icon.Video />
+            </Icon>
+            Video
+          </Tag>
+
+          <CodeBlock>{codeSamples.tagIcon}</CodeBlock>
+
+          <PropsTable
+            items={[
+              {
+                name: "isIcon?",
+                description: "Layout style",
+                type: "boolean",
+              },
+            ]}
+          />
+        </Section>
       </MainWrapper>
     </div>
   );


### PR DESCRIPTION
To make things cleaning in resolving https://github.com/nulib/repodev_planning_and_docs/issues/2443, this pull request adds a `isIcon` variant to the `<Tag/>` component. When set, the embeded `<Icon>` will be automatically sized and absolutely placed with proper spacing.

### Usage Example:
```
import { Icon, Tag } from '@nulib/design-system';

<Tag isInfo isIcon>
  <Icon>
    <Icon.Video />
  </Icon>
  Video
</Tag>
```

![image](https://user-images.githubusercontent.com/7376450/144504846-5ae86883-31c4-49ed-b8b7-fc0e1db19abc.png)
