### PR TITLE
Hard set `<Tag/>` line-height.

### DIFF
--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -17,6 +17,7 @@ export const Tag = styled("div", {
   textTransform: "uppercase",
   fontSize: "$2",
   objectFit: "contain",
+  lineHeight: "1em !important",
 
   "&:last-child": {
     marginRight: "0",


### PR DESCRIPTION
This is a quick fix that will hard-set the `<Tag/>` CSS line-height in consuming applications where line-height may differ.

### Example
The first `<Tag/>` **Video** has the line-height overridden to the same value in this PR, against the other two where line-height is inherited from consuming application.
![image](https://user-images.githubusercontent.com/7376450/144614673-a7fd979f-24b2-4e63-84f8-20c1bc0563ac.png)
