### PR TITLE
Add type=button attribute to Button component

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -12,5 +12,5 @@ type ButtonProps = ButtonComponentProps &
   ButtonVariants & { css?: CSS } & ButtonShape;
 
 export const Button = (props: ButtonProps) => {
-  return <StyledButton {...props} role="button" />;
+  return <StyledButton type="button" role="button" {...props} />;
 };


### PR DESCRIPTION
Add `type="button"` attribute to Button component so it doesn't accidentally submit forms when embedded in a form. 

Fixing in response to:  https://github.com/nulib/repodev_planning_and_docs/issues/2475