### PR TITLE
Align Popover arrow with close for data-align: end.

### DIFF
--- a/components/Popover.styled.tsx
+++ b/components/Popover.styled.tsx
@@ -55,7 +55,7 @@ const StyledContent = styled(Popover.Content, {
    */
   '&[data-align="end"]': {
     [`& ${StyledArrow}`]: {
-      margin: "0 2rem",
+      margin: "0 0.7rem",
     },
   },
 


### PR DESCRIPTION
This will align the Popover arrow with the Close button when we have a popover that happens to have a  `data-align: end` situation. This is most likely to occur in smaller viewports and where we have Popover triggers near the margins of the page.

### Current
![image](https://user-images.githubusercontent.com/7376450/146982943-6f65dbcf-13d9-4dd5-b579-8b245bc8f7df.png)

### With Changes
![image](https://user-images.githubusercontent.com/7376450/146982828-335f43fe-caa3-47df-a975-537960d65e56.png)
